### PR TITLE
Upgrade Twig from Underscored to Namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
 php:
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/process": "^2.7|^3.0|^4.0"
     },
     "conflict": {
-        "twig/twig": "<1.27"
+        "twig/twig": "<1.34|>=2,<2.4"
     },
     "replace": {
         "kriswallsmith/assetic": "self.version"

--- a/src/Assetic/Extension/Twig/AsseticExtension.php
+++ b/src/Assetic/Extension/Twig/AsseticExtension.php
@@ -13,8 +13,11 @@ namespace Assetic\Extension\Twig;
 
 use Assetic\Factory\AssetFactory;
 use Assetic\ValueSupplierInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+use Twig\TwigFunction;
 
-class AsseticExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+class AsseticExtension extends AbstractExtension implements GlobalsInterface
 {
     protected $factory;
     protected $functions;
@@ -48,7 +51,7 @@ class AsseticExtension extends \Twig_Extension implements \Twig_Extension_Global
     {
         $functions = array();
         foreach ($this->functions as $function => $filter) {
-            $functions[] = new \Twig_SimpleFunction($function, null, array(
+            $functions[] = new TwigFunction($function, null, array(
                     'needs_environment' => false, 'needs_context' => false,
                     'node_class' => '\Assetic\Extension\Twig\AsseticFilterNode',
                 ));

--- a/src/Assetic/Extension/Twig/AsseticFilterFunction.php
+++ b/src/Assetic/Extension/Twig/AsseticFilterFunction.php
@@ -11,7 +11,9 @@
 
 namespace Assetic\Extension\Twig;
 
-class AsseticFilterFunction extends \Twig_SimpleFunction
+use Twig\TwigFunction;
+
+class AsseticFilterFunction extends TwigFunction
 {
     public function __construct($name, $options = array())
     {

--- a/src/Assetic/Extension/Twig/AsseticFilterNode.php
+++ b/src/Assetic/Extension/Twig/AsseticFilterNode.php
@@ -11,9 +11,12 @@
 
 namespace Assetic\Extension\Twig;
 
-class AsseticFilterNode extends \Twig_Node_Expression_Function
+use Twig\Compiler;
+use Twig\Node\Expression\FunctionExpression;
+
+class AsseticFilterNode extends FunctionExpression
 {
-    protected function compileCallable(\Twig_Compiler $compiler)
+    protected function compileCallable(Compiler $compiler)
     {
         $compiler->raw(sprintf('$this->env->getExtension(\'Assetic\\Extension\\Twig\\AsseticExtension\')->getFilterInvoker(\'%s\')->invoke', $this->getAttribute('name')));
 

--- a/src/Assetic/Extension/Twig/AsseticNode.php
+++ b/src/Assetic/Extension/Twig/AsseticNode.php
@@ -12,8 +12,10 @@
 namespace Assetic\Extension\Twig;
 
 use Assetic\Asset\AssetInterface;
+use Twig\Compiler;
+use Twig\Node\Node;
 
-class AsseticNode extends \Twig_Node
+class AsseticNode extends Node
 {
     /**
      * Constructor.
@@ -25,7 +27,7 @@ class AsseticNode extends \Twig_Node
      *  * var_name: The name of the variable to expose to the body node
      *
      * @param AssetInterface $asset      The asset
-     * @param \Twig_Node     $body       The body node
+     * @param Node           $body       The body node
      * @param array          $inputs     An array of input strings
      * @param array          $filters    An array of filter strings
      * @param string         $name       The name of the asset
@@ -33,7 +35,7 @@ class AsseticNode extends \Twig_Node
      * @param integer        $lineno     The line number
      * @param string         $tag        The tag name
      */
-    public function __construct(AssetInterface $asset, \Twig_Node $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
+    public function __construct(AssetInterface $asset, Node $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
     {
         $nodes = array('body' => $body);
 
@@ -46,7 +48,7 @@ class AsseticNode extends \Twig_Node
         parent::__construct($nodes, $attributes, $lineno, $tag);
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $compiler->addDebugInfo($this);
 
@@ -90,7 +92,7 @@ class AsseticNode extends \Twig_Node
         ;
     }
 
-    protected function compileDebug(\Twig_Compiler $compiler)
+    protected function compileDebug(Compiler $compiler)
     {
         $i = 0;
         foreach ($this->getAttribute('asset') as $leaf) {
@@ -99,7 +101,7 @@ class AsseticNode extends \Twig_Node
         }
     }
 
-    protected function compileAsset(\Twig_Compiler $compiler, AssetInterface $asset, $name)
+    protected function compileAsset(Compiler $compiler, AssetInterface $asset, $name)
     {
         if ($vars = $asset->getVars()) {
             $compiler->write("// check variable conditions\n");
@@ -132,7 +134,7 @@ class AsseticNode extends \Twig_Node
         ;
     }
 
-    protected function compileAssetUrl(\Twig_Compiler $compiler, AssetInterface $asset, $name)
+    protected function compileAssetUrl(Compiler $compiler, AssetInterface $asset, $name)
     {
         if (!$vars = $asset->getVars()) {
             $compiler->repr($asset->getTargetPath());

--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -13,8 +13,13 @@ namespace Assetic\Extension\Twig;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Factory\AssetFactory;
+use Twig\Error\SyntaxError;
+use Twig\Node\Node;
+use Twig\NodeInterface;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
-class AsseticTokenParser extends \Twig_TokenParser
+class AsseticTokenParser extends AbstractTokenParser
 {
     private $factory;
     private $tag;
@@ -43,7 +48,7 @@ class AsseticTokenParser extends \Twig_TokenParser
         $this->extensions = $extensions;
     }
 
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
         $inputs = array();
         $filters = array();
@@ -55,73 +60,73 @@ class AsseticTokenParser extends \Twig_TokenParser
         );
 
         $stream = $this->parser->getStream();
-        while (!$stream->test(\Twig_Token::BLOCK_END_TYPE)) {
-            if ($stream->test(\Twig_Token::STRING_TYPE)) {
+        while (!$stream->test(Token::BLOCK_END_TYPE)) {
+            if ($stream->test(Token::STRING_TYPE)) {
                 // '@jquery', 'js/src/core/*', 'js/src/extra.js'
                 $inputs[] = $stream->next()->getValue();
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'filter')) {
+            } elseif ($stream->test(Token::NAME_TYPE, 'filter')) {
                 // filter='yui_js'
                 $stream->next();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $filters = array_merge($filters, array_filter(array_map('trim', explode(',', $stream->expect(\Twig_Token::STRING_TYPE)->getValue()))));
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'output')) {
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $filters = array_merge($filters, array_filter(array_map('trim', explode(',', $stream->expect(Token::STRING_TYPE)->getValue()))));
+            } elseif ($stream->test(Token::NAME_TYPE, 'output')) {
                 // output='js/packed/*.js' OR output='js/core.js'
                 $stream->next();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $attributes['output'] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'name')) {
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $attributes['output'] = $stream->expect(Token::STRING_TYPE)->getValue();
+            } elseif ($stream->test(Token::NAME_TYPE, 'name')) {
                 // name='core_js'
                 $stream->next();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $name = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'as')) {
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $name = $stream->expect(Token::STRING_TYPE)->getValue();
+            } elseif ($stream->test(Token::NAME_TYPE, 'as')) {
                 // as='the_url'
                 $stream->next();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $attributes['var_name'] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'debug')) {
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $attributes['var_name'] = $stream->expect(Token::STRING_TYPE)->getValue();
+            } elseif ($stream->test(Token::NAME_TYPE, 'debug')) {
                 // debug=true
                 $stream->next();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $attributes['debug'] = 'true' == $stream->expect(\Twig_Token::NAME_TYPE, array('true', 'false'))->getValue();
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'combine')) {
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $attributes['debug'] = 'true' == $stream->expect(Token::NAME_TYPE, array('true', 'false'))->getValue();
+            } elseif ($stream->test(Token::NAME_TYPE, 'combine')) {
                 // combine=true
                 $stream->next();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $attributes['combine'] = 'true' == $stream->expect(\Twig_Token::NAME_TYPE, array('true', 'false'))->getValue();
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, 'vars')) {
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $attributes['combine'] = 'true' == $stream->expect(Token::NAME_TYPE, array('true', 'false'))->getValue();
+            } elseif ($stream->test(Token::NAME_TYPE, 'vars')) {
                 // vars=['locale','browser']
                 $stream->next();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $stream->expect(\Twig_Token::PUNCTUATION_TYPE, '[');
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $stream->expect(Token::PUNCTUATION_TYPE, '[');
 
-                while ($stream->test(\Twig_Token::STRING_TYPE)) {
-                    $attributes['vars'][] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
+                while ($stream->test(Token::STRING_TYPE)) {
+                    $attributes['vars'][] = $stream->expect(Token::STRING_TYPE)->getValue();
 
-                    if (!$stream->test(\Twig_Token::PUNCTUATION_TYPE, ',')) {
+                    if (!$stream->test(Token::PUNCTUATION_TYPE, ',')) {
                         break;
                     }
 
                     $stream->next();
                 }
 
-                $stream->expect(\Twig_Token::PUNCTUATION_TYPE, ']');
-            } elseif ($stream->test(\Twig_Token::NAME_TYPE, $this->extensions)) {
+                $stream->expect(Token::PUNCTUATION_TYPE, ']');
+            } elseif ($stream->test(Token::NAME_TYPE, $this->extensions)) {
                 // an arbitrary configured attribute
                 $key = $stream->next()->getValue();
-                $stream->expect(\Twig_Token::OPERATOR_TYPE, '=');
-                $attributes[$key] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
+                $stream->expect(Token::OPERATOR_TYPE, '=');
+                $attributes[$key] = $stream->expect(Token::STRING_TYPE)->getValue();
             } else {
                 $token = $stream->getCurrent();
-                throw new \Twig_Error_Syntax(sprintf('Unexpected token "%s" of value "%s"', \Twig_Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getFilename());
+                throw new SyntaxError(sprintf('Unexpected token "%s" of value "%s"', Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getFilename());
             }
         }
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         $body = $this->parser->subparse(array($this, 'testEndTag'), true);
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         if ($this->single && 1 < count($inputs)) {
             $inputs = array_slice($inputs, -1);
@@ -141,14 +146,14 @@ class AsseticTokenParser extends \Twig_TokenParser
         return $this->tag;
     }
 
-    public function testEndTag(\Twig_Token $token)
+    public function testEndTag(Token $token)
     {
         return $token->test(array('end'.$this->getTag()));
     }
 
     /**
      * @param AssetInterface $asset
-     * @param \Twig_Node     $body
+     * @param Node           $body
      * @param array          $inputs
      * @param array          $filters
      * @param string         $name
@@ -156,9 +161,9 @@ class AsseticTokenParser extends \Twig_TokenParser
      * @param int            $lineno
      * @param string         $tag
      *
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function createBodyNode(AssetInterface $asset, \Twig_Node $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
+    protected function createBodyNode(AssetInterface $asset, Node $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
     {
         $reflector = new \ReflectionMethod($this, 'createNode');
 
@@ -172,25 +177,25 @@ class AsseticTokenParser extends \Twig_TokenParser
     }
 
     /**
-     * @param AssetInterface      $asset
-     * @param \Twig_NodeInterface $body
-     * @param array               $inputs
-     * @param array               $filters
-     * @param string              $name
-     * @param array               $attributes
-     * @param int                 $lineno
-     * @param string              $tag
+     * @param AssetInterface $asset
+     * @param NodeInterface  $body
+     * @param array          $inputs
+     * @param array          $filters
+     * @param string         $name
+     * @param array          $attributes
+     * @param int            $lineno
+     * @param string         $tag
      *
-     * @return \Twig_Node
+     * @return Node
      *
      * @deprecated since 1.3.0, to be removed in 2.0. Use createBodyNode instead.
      */
-    protected function createNode(AssetInterface $asset, \Twig_NodeInterface $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
+    protected function createNode(AssetInterface $asset, NodeInterface $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
     {
         @trigger_error(sprintf('The %s method is deprecated since 1.3 and will be removed in 2.0. Use createBodyNode instead.', __METHOD__), E_USER_DEPRECATED);
 
-        if (!$body instanceof \Twig_Node) {
-            throw new \InvalidArgumentException('The body must be a Twig_Node. Custom implementations of Twig_NodeInterface are not supported.');
+        if (!$body instanceof Node) {
+            throw new \InvalidArgumentException('The body must be a \Twig\Node. Custom implementations of \Twig\NodeInterface are not supported.');
         }
 
         return new AsseticNode($asset, $body, $inputs, $filters, $name, $attributes, $lineno, $tag);

--- a/src/Assetic/Extension/Twig/TwigFormulaLoader.php
+++ b/src/Assetic/Extension/Twig/TwigFormulaLoader.php
@@ -14,6 +14,9 @@ namespace Assetic\Extension\Twig;
 use Assetic\Factory\Loader\FormulaLoaderInterface;
 use Assetic\Factory\Resource\ResourceInterface;
 use Psr\Log\LoggerInterface;
+use Twig\Environment;
+use Twig\Node\Node;
+use Twig\Source;
 
 /**
  * Loads asset formulae from Twig templates.
@@ -25,7 +28,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
     private $twig;
     private $logger;
 
-    public function __construct(\Twig_Environment $twig, LoggerInterface $logger = null)
+    public function __construct(Environment $twig, LoggerInterface $logger = null)
     {
         $this->twig = $twig;
         $this->logger = $logger;
@@ -34,7 +37,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
     public function load(ResourceInterface $resource)
     {
         try {
-            $tokens = $this->twig->tokenize(new \Twig_Source($resource->getContent(), (string) $resource));
+            $tokens = $this->twig->tokenize(new Source($resource->getContent(), (string) $resource));
             $nodes  = $this->twig->parse($tokens);
         } catch (\Exception $e) {
             if ($this->logger) {
@@ -50,11 +53,11 @@ class TwigFormulaLoader implements FormulaLoaderInterface
     /**
      * Loads assets from the supplied node.
      *
-     * @param \Twig_Node $node
+     * @param Node $node
      *
      * @return array An array of asset formulae indexed by name
      */
-    private function loadNode(\Twig_Node $node)
+    private function loadNode(Node $node)
     {
         $formulae = array();
 
@@ -92,7 +95,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
         }
 
         foreach ($node as $child) {
-            if ($child instanceof \Twig_Node) {
+            if ($child instanceof Node) {
                 $formulae += $this->loadNode($child);
             }
         }

--- a/src/Assetic/Extension/Twig/TwigResource.php
+++ b/src/Assetic/Extension/Twig/TwigResource.php
@@ -12,6 +12,8 @@
 namespace Assetic\Extension\Twig;
 
 use Assetic\Factory\Resource\ResourceInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\LoaderInterface;
 
 /**
  * A Twig template resource.
@@ -23,7 +25,7 @@ class TwigResource implements ResourceInterface
     private $loader;
     private $name;
 
-    public function __construct(\Twig_LoaderInterface $loader, $name)
+    public function __construct(LoaderInterface $loader, $name)
     {
         $this->loader = $loader;
         $this->name = $name;
@@ -35,7 +37,7 @@ class TwigResource implements ResourceInterface
             return method_exists($this->loader, 'getSourceContext')
                 ? $this->loader->getSourceContext($this->name)->getCode()
                 : $this->loader->getSource($this->name);
-        } catch (\Twig_Error_Loader $e) {
+        } catch (LoaderError $e) {
             return '';
         }
     }
@@ -44,7 +46,7 @@ class TwigResource implements ResourceInterface
     {
         try {
             return $this->loader->isFresh($this->name, $timestamp);
-        } catch (\Twig_Error_Loader $e) {
+        } catch (LoaderError $e) {
             return false;
         }
     }

--- a/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
+++ b/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
@@ -16,6 +16,8 @@ use Assetic\Extension\Twig\AsseticExtension;
 use Assetic\Asset\AssetCollection;
 use Assetic\Asset\FileAsset;
 use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class AsseticExtensionTest extends TestCase
 {
@@ -35,7 +37,7 @@ class AsseticExtensionTest extends TestCase
     private $factory;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -46,7 +48,7 @@ class AsseticExtensionTest extends TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Twig_Environment')) {
+        if (!class_exists('\Twig\Environment')) {
             $this->markTestSkipped('Twig is not installed.');
         }
 
@@ -59,7 +61,7 @@ class AsseticExtensionTest extends TestCase
         $this->factory->setAssetManager($this->am);
         $this->factory->setFilterManager($this->fm);
 
-        $this->twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        $this->twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
         $this->twig->addExtension(new AsseticExtension($this->factory, array(), $this->valueSupplier));
     }
 
@@ -204,7 +206,7 @@ class AsseticExtensionTest extends TestCase
             ->with('some_filter')
             ->will($this->returnValue($filter));
 
-        $this->twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/templates'));
+        $this->twig = new Environment(new FilesystemLoader(__DIR__.'/templates'));
         $this->twig->addExtension(new AsseticExtension($this->factory, array(
             'some_func' => array(
                 'filter' => 'some_filter',
@@ -245,7 +247,7 @@ class AsseticExtensionTest extends TestCase
     }
 
     /**
-     * @expectedException \Twig_Error_Syntax
+     * @expectedException \Twig\Error\SyntaxError
      */
     public function testUnclosedTag()
     {

--- a/tests/Assetic/Test/Extension/Twig/TwigFormulaLoaderTest.php
+++ b/tests/Assetic/Test/Extension/Twig/TwigFormulaLoaderTest.php
@@ -15,6 +15,8 @@ use Assetic\Factory\AssetFactory;
 use Assetic\Extension\Twig\AsseticExtension;
 use Assetic\Extension\Twig\TwigFormulaLoader;
 use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class TwigFormulaLoaderTest extends TestCase
 {
@@ -27,7 +29,7 @@ class TwigFormulaLoaderTest extends TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Twig_Environment')) {
+        if (!class_exists('\Twig\Environment')) {
             $this->markTestSkipped('Twig is not installed.');
         }
 
@@ -38,7 +40,7 @@ class TwigFormulaLoaderTest extends TestCase
         $factory->setAssetManager($this->am);
         $factory->setFilterManager($this->fm);
 
-        $twig = new \Twig_Environment(new \Twig_Loader_Array(array()));
+        $twig = new Environment(new ArrayLoader(array()));
         $twig->addExtension(new AsseticExtension($factory, array(
             'some_func' => array(
                 'filter' => 'some_filter',

--- a/tests/Assetic/Test/Extension/Twig/TwigResourceTest.php
+++ b/tests/Assetic/Test/Extension/Twig/TwigResourceTest.php
@@ -13,24 +13,25 @@ namespace Assetic\Test\Extension\Twig;
 
 use Assetic\Extension\Twig\TwigResource;
 use PHPUnit\Framework\TestCase;
+use Twig\Error\LoaderError;
 
 class TwigResourceTest extends TestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Twig_Environment')) {
+        if (!class_exists('\Twig\Environment')) {
             $this->markTestSkipped('Twig is not installed.');
         }
     }
 
     public function testInvalidTemplateNameGetContent()
     {
-        $loader = $this->prophesize('Twig_LoaderInterface');
-        if (!method_exists('Twig_LoaderInterface', 'getSourceContext')) {
-            $loader->willImplement('Twig_SourceContextLoaderInterface');
+        $loader = $this->prophesize('\Twig\Loader\LoaderInterface');
+        if (!method_exists('\Twig\Loader\LoaderInterface', 'getSourceContext')) {
+            $loader->willImplement('\Twig\Loader\SourceContextLoaderInterface');
         }
 
-        $loader->getSourceContext('asdf')->willThrow(new \Twig_Error_Loader(''));
+        $loader->getSourceContext('asdf')->willThrow(new LoaderError(''));
 
         $resource = new TwigResource($loader->reveal(), 'asdf');
         $this->assertEquals('', $resource->getContent());
@@ -38,11 +39,11 @@ class TwigResourceTest extends TestCase
 
     public function testInvalidTemplateNameIsFresh()
     {
-        $loader = $this->getMockBuilder('Twig_LoaderInterface')->getMock();
+        $loader = $this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock();
         $loader->expects($this->once())
             ->method('isFresh')
             ->with('asdf', 1234)
-            ->will($this->throwException(new \Twig_Error_Loader('')));
+            ->will($this->throwException(new LoaderError('')));
 
         $resource = new TwigResource($loader, 'asdf');
         $this->assertFalse($resource->isFresh(1234));


### PR DESCRIPTION
The main reason for this is because Twig shows the deprecation notice like
> User Deprecated: Using the "Twig_Source" class is deprecated since Twig version 2.7, use "Twig\Source" instead.